### PR TITLE
Update simple-wc-rest-client.php

### DIFF
--- a/simple-wc-rest-client.php
+++ b/simple-wc-rest-client.php
@@ -85,7 +85,11 @@ class SimpleWcRestClient
 		$consumer_secret = $request_data['consumer_secret'];
 		$options         = $request_data['options'];
 		$endpoint        = $request_data['endpoint'];
-		$data 			 = ($request_data['data'] === null || json_decode($request_data['data']) == null) ? [] : (array) json_decode($request_data['data']);
+		if (is_array($request_data['data']))
+			$data = $request_data['data'];
+		else
+			$data = ($request_data['data'] === null || json_decode($request_data['data']) == null) ? [] : (array) json_decode($request_data['data']);
+
 		$results;
 
 		try{
@@ -163,7 +167,11 @@ class SimpleWcRestClient
 		$consumer_secret = $request_data['consumer_secret'];
 		$endpoint        = $request_data['endpoint'];
 		$options = $request_data['options'];
-		$parameters = ($request_data['parameters'] === null || json_decode($request_data['parameters']) == null) ? [] : (array) json_decode($request_data['parameters']);
+		if (is_array($request_data['parameters']))
+			$parameters = $request_data['parameters'];
+		else
+			$parameters = ($request_data['parameters'] === null || json_decode($request_data['parameters']) == null) ? [] : (array) json_decode($request_data['parameters']);
+
 		$results;
 
 		try{


### PR DESCRIPTION
Fixed PHP Warning:  json_decode() expects parameter 1 to be string, array given in /wp-content/plugins/simple-wc-rest-client-master/simple-wc-rest-client.php

Issue occurs in the following requests:
```
public void testGetRequest() {
        String url = "http://xxxx.com/wp-json/swrc/v1/get";
        OkHttpClient client = new OkHttpClient();
        RequestBody formBody = new FormBody.Builder()
                .add("base_url", "http://xxxx.com")
                .add("consumer_key", "ck_0000")
                .add("consumer_secret", "cs_0000")
                .add("options[wp_api]", "true")
                .add("options[version]", "wc/v1")
                .add("endpoint", "products")
                .add("parameters[page]", "1")
                .add("parameters[per_page]", "2")
                .build();

        Request request = new Request.Builder()
                .url(url)
                .post(formBody)
                .build();

        client.newCall(request).enqueue(new Callback() {
            @Override
            public void onFailure(Call call, IOException e) {
                e.printStackTrace();
            }

            @Override
            public void onResponse(Call call, Response response) throws IOException {
                System.out.println("RESPONSE CODE: "+response.code());
                System.out.println(response.body().string());
            }
        });
    }
```

Or:
```
public void testPostRequest() {
        String url = "http://xxxx.com/wp-json/swrc/v1/post";
        OkHttpClient client = new OkHttpClient();
        RequestBody formBody = new FormBody.Builder()
                .add("base_url", "http://xxxx.com")
                .add("consumer_key", "ck_0000")
                .add("consumer_secret", "cs_0000")
                .add("options[wp_api]", "true")
                .add("options[version]", "wc/v1")
                .add("endpoint", "products")
                .add("data[name]", "Ultra T-Shirt")
                .add("data[regular_price]", "125000")
                .add("data[type]", "simple")
                .add("data[description]", "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.")
                .build();

        Request request = new Request.Builder()
                .url(url)
                .post(formBody)
                .build();

        client.newCall(request).enqueue(new Callback() {
            @Override
            public void onFailure(Call call, IOException e) {
                e.printStackTrace();
            }

            @Override
            public void onResponse(Call call, Response response) throws IOException {
                System.out.println("RESPONSE CODE: "+response.code());
                System.out.println("RESPONSE: "+response.body().string());
            }
        });
    }
```